### PR TITLE
fix: Update the Tailwind CSS logo's broken CDN link.

### DIFF
--- a/components/global/Footer.tsx
+++ b/components/global/Footer.tsx
@@ -101,7 +101,7 @@ function Footer() {
               </span>
               <span>
                 <img
-                  src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-plain.svg"
+                  src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-original.svg"
                   width="26"
                   title="TailwindCSS"
                 />

--- a/data/content/home.ts
+++ b/data/content/home.ts
@@ -29,7 +29,7 @@ export const skills: Skill[] = [
   },
   {
     title: "TailwindCSS",
-    icon: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-plain.svg",
+    icon: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-original.svg",
   },
   {
     title: "React",


### PR DESCRIPTION
## This Pull Request Fixes #5  Issue

### Changes Made:

- The only changes made to the code are the cdn link of the Tailwind CSS logo in the tech stack section and the footer navigation.
- The only altered files are components\global\Footer.tsx and data\content\home.ts.

### Fixes: #5 

### BUG:
![image](https://github.com/BraydenTW/braydentw.io/assets/113609441/cd9d8c07-9ee7-4183-9100-ff0aad21cbd6)

![image](https://github.com/BraydenTW/braydentw.io/assets/113609441/b935a7cb-bf58-4dff-b04f-32c39b2f7755)

### Result after fix:
![tech-stack-fix](https://github.com/BraydenTW/braydentw.io/assets/113609441/eb3513f4-1ca9-43ed-9e7f-d2912488419e)

![footer-fix](https://github.com/BraydenTW/braydentw.io/assets/113609441/837e9d99-9dc0-431f-a195-2c1d8a7e8211)


### Build Info:
![build1](https://github.com/BraydenTW/braydentw.io/assets/113609441/8a8d2f78-d336-46e6-b3f0-f537c3959146)

![build2](https://github.com/BraydenTW/braydentw.io/assets/113609441/df85e6cc-47c5-415b-acfb-c5f6d5b22f9d)

### Git Interactions:
![git1](https://github.com/BraydenTW/braydentw.io/assets/113609441/0effb851-8fcb-481e-8f59-5ce888bae082)

![git2](https://github.com/BraydenTW/braydentw.io/assets/113609441/d7057487-ae39-452d-b24c-528817128690)

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
- Go to home page of https://braydentw.io/
- Scroll down to the tech stack section and the footer navigation of the page.